### PR TITLE
Fix exports naming discrepancy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "./prettier": "./config/prettier.js",
     "./ts-reset": "./config/ts-reset.d.ts",
     "./tsconfig-node": "./config/tsconfig-node.json",
-    "./typescript-react": "./config/tsconfig-react.json"
+    "./tsconfig-react": "./config/tsconfig-react.json"
   },
   "scripts": {
     "test": "run-p test:*",


### PR DESCRIPTION
In the README, Step 4 describes choosing between `@fisch0920/config/tsconfig-node` or `@fisch0920/config/tsconfig-react`, but in my project, `@fisch0920/config/tsconfig-node` couldn't be found when I tried to extend it in  `tsconfig.json`.

I think it's because the `exports` entry in `package.json` exports `./config/tsconfig-react.json` as `./typescript-react`. 

Submitting this change to update exports to be consistent with docs and other naming.